### PR TITLE
RC 3.1 Fixes/Tweaks

### DIFF
--- a/app/components/-report/campaign/creative.js
+++ b/app/components/-report/campaign/creative.js
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
-import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager';
+import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 
 import reportByDay from 'fortnight/gql/queries/campaign/reports/creative-by-day';
 import creativeMetrics from 'fortnight/gql/queries/campaign/creative-metrics';
 
-export default Component.extend(ObjectQueryManager, {
+export default Component.extend(ComponentQueryManager, {
   isReportRunning: false,
   areMetricsLoading: false,
 
@@ -20,7 +20,7 @@ export default Component.extend(ObjectQueryManager, {
         endDate: endDate.startOf('day').valueOf(),
       };
       try {
-        const { reports } = await this.get('apollo').query({ query: reportByDay, variables }, 'campaignCreative');
+        const { reports } = await this.get('apollo').watchQuery({ query: reportByDay, variables }, 'campaignCreative');
         this.set('rows', reports.byDay);
       } catch (e) {
         this.get('graphErrors').show(e);
@@ -35,7 +35,7 @@ export default Component.extend(ObjectQueryManager, {
         input: { campaignId: this.get('campaignId'), creativeId: this.get('creativeId') },
       };
       try {
-        const { metrics } = await this.get('apollo').query({ query: creativeMetrics, variables }, 'campaignCreative');
+        const { metrics } = await this.get('apollo').watchQuery({ query: creativeMetrics, variables }, 'campaignCreative');
         this.set('metrics', metrics);
       } catch (e) {
         this.get('graphErrors').show(e);

--- a/app/components/-report/sort-field.js
+++ b/app/components/-report/sort-field.js
@@ -1,0 +1,39 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  tagName: 'a',
+
+  classNames: ['clickable'],
+  attributeBindings: ['href'],
+
+  href: '#',
+
+  key: null,
+  sortBy: '',
+  ascending: false,
+  reset: true,
+
+  init() {
+    this._super(...arguments);
+    this.set('originalSortBy', this.get('sortBy'));
+  },
+
+  click(event) {
+    event.preventDefault();
+    if (this.get('isActive')) {
+      if (this.get('reset') && this.get('ascending') === false) {
+        this.set('sortBy', this.get('originalSortBy'));
+      } else {
+        this.toggleProperty('ascending');
+      }
+    } else {
+      this.set('sortBy', this.get('key'));
+      this.set('ascending', true);
+    }
+  },
+
+  isActive: computed('key', 'sortBy', function() {
+    return this.get('key') === this.get('sortBy');
+  }),
+});

--- a/app/components/-report/story/acquisition.js
+++ b/app/components/-report/story/acquisition.js
@@ -1,12 +1,12 @@
 import Component from '@ember/component';
-import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager';
+import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 import ActionMixin from 'fortnight/mixins/action-mixin';
 import { computed } from '@ember/object';
 import numeral from 'numeral';
 
 import query from 'fortnight/gql/queries/story/reports/acquisition';
 
-export default Component.extend(ActionMixin, ObjectQueryManager, {
+export default Component.extend(ActionMixin, ComponentQueryManager, {
 
   init() {
     this._super(...arguments);
@@ -52,7 +52,7 @@ export default Component.extend(ActionMixin, ObjectQueryManager, {
     this.startAction();
     const variables = { input: { id: this.get('storyId') } };
     try {
-      const { reports } = await this.get('apollo').query({ query, variables }, 'story');
+      const { reports } = await this.get('apollo').watchQuery({ query, variables }, 'story');
       this.set('rows', reports.acquisition);
     } catch (e) {
       this.get('graphErrors').show(e);

--- a/app/components/-report/story/devices.js
+++ b/app/components/-report/story/devices.js
@@ -1,12 +1,12 @@
 import Component from '@ember/component';
-import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager';
+import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 import ActionMixin from 'fortnight/mixins/action-mixin';
 import { computed } from '@ember/object';
 import numeral from 'numeral';
 
 import query from 'fortnight/gql/queries/story/reports/devices';
 
-export default Component.extend(ActionMixin, ObjectQueryManager, {
+export default Component.extend(ActionMixin, ComponentQueryManager, {
 
   init() {
     this._super(...arguments);
@@ -52,7 +52,7 @@ export default Component.extend(ActionMixin, ObjectQueryManager, {
     this.startAction();
     const variables = { input: { id: this.get('storyId') } };
     try {
-      const { reports } = await this.get('apollo').query({ query, variables }, 'story');
+      const { reports } = await this.get('apollo').watchQuery({ query, variables }, 'story');
       this.set('rows', reports.devices);
     } catch (e) {
       this.get('graphErrors').show(e);

--- a/app/components/-report/story/metrics-by-day.js
+++ b/app/components/-report/story/metrics-by-day.js
@@ -1,9 +1,9 @@
 import Component from '@ember/component';
-import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager';
+import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 
 import query from 'fortnight/gql/queries/story/reports/by-day';
 
-export default Component.extend( ObjectQueryManager, {
+export default Component.extend(ComponentQueryManager, {
   isReportRunning: false,
 
   actions: {
@@ -15,7 +15,7 @@ export default Component.extend( ObjectQueryManager, {
         endDate: endDate.valueOf(),
       };
       try {
-        const { reports } = await this.get('apollo').query({ query, variables }, 'story');
+        const { reports } = await this.get('apollo').watchQuery({ query, variables }, 'story');
         this.set('rows', reports.byDay);
       } catch (e) {
         this.get('graphErrors').show(e);

--- a/app/components/-report/story/metrics.js
+++ b/app/components/-report/story/metrics.js
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
-import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager';
+import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 import ActionMixin from 'fortnight/mixins/action-mixin';
 
 import query from 'fortnight/gql/queries/story/metrics';
 
-export default Component.extend(ActionMixin, ObjectQueryManager, {
+export default Component.extend(ActionMixin, ComponentQueryManager, {
   classNames: ['row'],
 
   init() {
@@ -16,7 +16,7 @@ export default Component.extend(ActionMixin, ObjectQueryManager, {
     this.startAction();
     const variables = { input: { id: this.get('storyId') } };
     try {
-      const { metrics } = await this.get('apollo').query({ query, variables }, 'story');
+      const { metrics } = await this.get('apollo').watchQuery({ query, variables }, 'story');
       this.set('metrics', metrics);
     } catch (e) {
       this.get('graphErrors').show(e);

--- a/app/components/campaign-creative.js
+++ b/app/components/campaign-creative.js
@@ -34,7 +34,7 @@ export default Component.extend(ActionMixin, {
 
       const mutation = removeCreative;
       const variables = { input: { campaignId, creativeId } };
-      const refetchQueries = ['CampaignCreatives', 'CampaignHash'];
+      const refetchQueries = ['CampaignCreatives', 'PortalCampaignsManageMaterials'];
       try {
         await this.get('apollo').mutate({ mutation, variables, refetchQueries }, 'removeCampaignCreative');
       } catch (e) {

--- a/app/components/campaign-creative.js
+++ b/app/components/campaign-creative.js
@@ -39,6 +39,7 @@ export default Component.extend(ActionMixin, {
         await this.get('apollo').mutate({ mutation, variables, refetchQueries }, 'removeCampaignCreative');
       } catch (e) {
         this.get('graphErrors').show(e);
+      } finally {
         this.endAction();
       }
     },
@@ -53,6 +54,7 @@ export default Component.extend(ActionMixin, {
         await this.get('apollo').mutate({ mutation, variables }, 'campaignCreativeStatus');
       } catch (e) {
         this.get('graphErrors').show(e);
+      } finally {
         this.endAction();
       }
     },

--- a/app/components/dashboard/publisher-breakouts.js
+++ b/app/components/dashboard/publisher-breakouts.js
@@ -63,7 +63,7 @@ export default Component.extend(ComponentQueryManager, {
     };
     const variables = { input };
     try {
-      const rows = await this.get('apollo').query({ query, variables }, 'publisherMetricBreakouts');
+      const rows = await this.get('apollo').watchQuery({ query, variables }, 'publisherMetricBreakouts');
       this.set('rows', rows);
     } catch (e) {
       this.get('graphErrors').show(e);

--- a/app/components/image-crop-preview.js
+++ b/app/components/image-crop-preview.js
@@ -11,8 +11,3 @@ export default Component.extend({
     }
   }
 });
-
-
-
-
-

--- a/app/components/image-crop-preview.js
+++ b/app/components/image-crop-preview.js
@@ -7,7 +7,7 @@ export default Component.extend({
     this._super(...arguments);
     if (!isArray(this.get('aspectRatios'))) {
       // ['21:9', '16:9', '3:2', '4:3', '1:1']
-      this.set('aspectRatios', ['16:9', '4:3', '1:1']);
+      this.set('aspectRatios', ['1.91:1', '16:9', '4:3', '1:1']);
     }
   }
 });

--- a/app/components/materials/contacts-builder.js
+++ b/app/components/materials/contacts-builder.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import ActionMixin from 'fortnight/mixins/action-mixin';
+import ActionMixin from 'fortnight/mixins/action';
 import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 
 import removeCampaignExternalContact from 'fortnight/gql/mutations/campaign/remove-external-contact';

--- a/app/components/materials/contacts-builder/modal.js
+++ b/app/components/materials/contacts-builder/modal.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import ActionMixin from 'fortnight/mixins/action-mixin';
+import ActionMixin from 'fortnight/mixins/action';
 import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 
 import campaignExternalContact from 'fortnight/gql/mutations/campaign/external-contact';

--- a/app/components/materials/contacts-builder/modal.js
+++ b/app/components/materials/contacts-builder/modal.js
@@ -24,7 +24,7 @@ export default Component.extend(ActionMixin, ComponentQueryManager, {
         payload,
       };
       const variables = { input };
-      const refetchQueries = ['CampaignHash'];
+      const refetchQueries = ['PortalCampaignsManageMaterials'];
       try {
         await this.get('apollo').mutate({ mutation: campaignExternalContact, variables, refetchQueries }, 'campaignExternalContact');
         this.get('modal').send('hide');

--- a/app/components/materials/story-builder.js
+++ b/app/components/materials/story-builder.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import ActionMixin from 'fortnight/mixins/action-mixin';
+import ActionMixin from 'fortnight/mixins/action';
 import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
 
 import storyTitle from 'fortnight/gql/mutations/story/title';

--- a/app/components/story-published-at.js
+++ b/app/components/story-published-at.js
@@ -23,16 +23,19 @@ export default Component.extend({
     return moment().startOf('day');
   }),
 
+  onSelect(value) {
+    const fn = this.get('onSelect');
+    if (typeof fn === 'function') {
+      fn(value);
+    }
+  },
+
   actions: {
     removeDate() {
-      this.set('selected', null);
-      // eslint-disable-next-line
-      this.sendAction('onSelect', null);
+      this.onSelect(null);
     },
     setPublishedAt(selected) {
-      this.set('selected', moment(selected).startOf('day'));
-      // eslint-disable-next-line
-      this.sendAction('onSelect', selected);
+      this.onSelect(moment(selected).startOf('day'));
     },
   },
 });

--- a/app/controllers/manage/account.js
+++ b/app/controllers/manage/account.js
@@ -22,7 +22,10 @@ export default Controller.extend(ActionMixin, {
 
       const payload = {
         name,
-        settings: { reservePct: settings.reservePct || 0 },
+        settings: {
+          reservePct: settings.reservePct || 0,
+          requiredCreatives: settings.requiredCreatives || 1,
+        },
       };
       const variables = { input: { id, payload } };
       try {

--- a/app/controllers/manage/story/edit/index.js
+++ b/app/controllers/manage/story/edit/index.js
@@ -5,11 +5,28 @@ import ActionMixin from 'fortnight/mixins/action-mixin';
 
 import updateStory from 'fortnight/gql/mutations/story/update';
 import deleteStory from 'fortnight/gql/mutations/story/delete';
+import storyPublishedAt from 'fortnight/gql/mutations/story/published-at';
 
 export default Controller.extend(ActionMixin, {
   apollo: inject(),
 
   actions: {
+    async setPublishedAt(id, publishedAt) {
+      this.startAction();
+      const variables = {
+        id,
+        value: publishedAt ? publishedAt.valueOf() : null,
+      }
+      const mutation = storyPublishedAt;
+      try {
+        await this.get('apollo').mutate({ mutation, variables }, 'storyPublishedAt');
+      } catch (e) {
+        this.get('graphErrors').show(e);
+      } finally {
+        this.endAction();
+      }
+    },
+
     /**
      * Updates the story.
      *

--- a/app/controllers/portal/campaigns/manage/materials.js
+++ b/app/controllers/portal/campaigns/manage/materials.js
@@ -10,6 +10,17 @@ import assignCampaignValue from 'fortnight/gql/mutations/campaign/assign-value';
 export default Controller.extend(ActionMixin, {
   apollo: inject(),
 
+  activeCreatives: computed.filterBy('model.creatives', 'active', true),
+
+  remainingCreatives: computed('model.requiredCreatives', 'activeCreatives.length', function() {
+    return this.get('model.requiredCreatives') - this.get('activeCreatives.length');
+  }),
+
+  remainingCreativesLabel: computed('remainingCreatives', function() {
+    if (this.get('remainingCreatives') > 1) return 'creatives';
+    return 'creative';
+  }),
+
   actions: {
     async saveField(field, label, { value }) {
       this.startAction();

--- a/app/controllers/portal/campaigns/manage/materials.js
+++ b/app/controllers/portal/campaigns/manage/materials.js
@@ -10,11 +10,6 @@ import assignCampaignValue from 'fortnight/gql/mutations/campaign/assign-value';
 export default Controller.extend(ActionMixin, {
   apollo: inject(),
 
-  canRemoveCreatives: computed('model.creatives.length', function() {
-    return this.get('model.creatives.length') > 1;
-  }),
-
-
   actions: {
     async saveField(field, label, { value }) {
       this.startAction();

--- a/app/controllers/portal/campaigns/manage/materials.js
+++ b/app/controllers/portal/campaigns/manage/materials.js
@@ -10,8 +10,8 @@ import assignCampaignValue from 'fortnight/gql/mutations/campaign/assign-value';
 export default Controller.extend(ActionMixin, {
   apollo: inject(),
 
-  canRemoveCreatives: computed('model.campaign.creatives.length', function() {
-    return this.get('model.campaign.creatives.length') > 1;
+  canRemoveCreatives: computed('model.creatives.length', function() {
+    return this.get('model.creatives.length') > 1;
   }),
 
 
@@ -19,7 +19,7 @@ export default Controller.extend(ActionMixin, {
     async saveField(field, label, { value }) {
       this.startAction();
       const input = {
-        id: this.get('model.campaign.id'),
+        id: this.get('model.id'),
         field,
         value,
       };
@@ -46,7 +46,7 @@ export default Controller.extend(ActionMixin, {
 
     async updateUrl({ url }) {
       this.startAction();
-      const campaignId = this.get('model.campaign.id');
+      const campaignId = this.get('model.id');
       const variables = { input: { campaignId, url } };
 
       try {

--- a/app/controllers/portal/campaigns/manage/materials.js
+++ b/app/controllers/portal/campaigns/manage/materials.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { inject } from '@ember/service';
 import { isURL } from 'validator';
-import ActionMixin from 'fortnight/mixins/action-mixin';
+import ActionMixin from 'fortnight/mixins/action';
 
 import mutation from 'fortnight/gql/mutations/campaign/url';
 import assignCampaignValue from 'fortnight/gql/mutations/campaign/assign-value';

--- a/app/controllers/portal/campaigns/manage/materials/creatives/create.js
+++ b/app/controllers/portal/campaigns/manage/materials/creatives/create.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { inject } from '@ember/service';
 import { set, get } from '@ember/object';
-import ActionMixin from 'fortnight/mixins/action-mixin';
+import ActionMixin from 'fortnight/mixins/action';
 
 import mutation from 'fortnight/gql/mutations/campaign/add-creative';
 

--- a/app/controllers/portal/campaigns/manage/materials/creatives/create.js
+++ b/app/controllers/portal/campaigns/manage/materials/creatives/create.js
@@ -12,14 +12,13 @@ export default Controller.extend(ActionMixin, {
   actions: {
     /**
      * Handles the image once uploaded.
-     * In this case, sets it to the `creative` model.
      *
      * @param {object} image
      * @param {string} image.id
      * @param {string} image.link
      */
     async handleCreativeImage({ id, link }) {
-      set(this.get('model'), 'creative.image', { id, src: link });
+      set(this.get('model'), 'image', { id, src: link });
     },
 
     /**
@@ -34,7 +33,7 @@ export default Controller.extend(ActionMixin, {
       this.startAction();
       try {
         await this.get('imageLoader').setImageFocalPoint(imageId, { x, y });
-        set(this.get('model.creative'), 'image.focalPoint', { x, y });
+        set(this.get('model'), 'image.focalPoint', { x, y });
       } catch (e) {
         this.get('graphErrors').show(e);
       } finally {
@@ -49,12 +48,12 @@ export default Controller.extend(ActionMixin, {
     async create({ title, teaser, image }) {
       this.startAction();
       const active = true;
-      const campaignId = this.get('model.campaign.id');
+      const campaignId = this.get('campaign.id');
       const imageId = get(image, 'id');
 
       const payload = { title, teaser, active, imageId };
       const variables = { input: { campaignId, payload } };
-      const refetchQueries = ['CampaignHash'];
+      const refetchQueries = ['PortalCampaignsManageMaterials'];
 
       try {
         await this.get('apollo').mutate({ mutation, variables, refetchQueries }, 'addCampaignCreative');

--- a/app/controllers/portal/campaigns/manage/materials/creatives/edit.js
+++ b/app/controllers/portal/campaigns/manage/materials/creatives/edit.js
@@ -20,8 +20,8 @@ export default Controller.extend(ActionMixin, {
     async handleCreativeImage({ id }) {
       this.startAction();
 
-      const creativeId = this.get('model.creative.id');
-      const campaignId = this.get('model.campaign.id');
+      const creativeId = this.get('model.id');
+      const campaignId = this.get('campaign.id');
 
       const mutation = campaignCreativeImage;
       const input = { campaignId, creativeId, imageId: id };
@@ -61,7 +61,7 @@ export default Controller.extend(ActionMixin, {
     async updateDetails({ id, title, teaser }) {
       this.startAction();
 
-      const campaignId = this.get('model.campaign.id');
+      const campaignId = this.get('campaign.id');
       const payload = { title, teaser, active: true };
 
       const mutation = campaignCreativeDetails;

--- a/app/controllers/portal/campaigns/manage/materials/creatives/edit.js
+++ b/app/controllers/portal/campaigns/manage/materials/creatives/edit.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { inject } from '@ember/service';
-import ActionMixin from 'fortnight/mixins/action-mixin';
+import ActionMixin from 'fortnight/mixins/action';
 
 import campaignCreativeDetails from 'fortnight/gql/mutations/campaign/creative-details';
 import campaignCreativeImage from 'fortnight/gql/mutations/campaign/creative-image';

--- a/app/controllers/portal/campaigns/manage/report/summary.js
+++ b/app/controllers/portal/campaigns/manage/report/summary.js
@@ -19,7 +19,7 @@ export default Controller.extend({
         endDate: endDate.startOf('day').valueOf(),
       };
       try {
-        const { reports } = await this.get('apollo').query({ query: reportByDay, variables }, 'campaignHash');
+        const { reports } = await this.get('apollo').watchQuery({ query: reportByDay, variables }, 'campaignHash');
         this.set('rows', reports.byDay);
       } catch (e) {
         this.get('graphErrors').show(e);
@@ -34,7 +34,7 @@ export default Controller.extend({
         input: { hash: this.get('model.campaign.hash'), advertiserId: this.get('model.advertiser.id') },
       };
       try {
-        const { metrics } = await this.get('apollo').query({ query: campaignMetrics, variables }, 'campaignHash');
+        const { metrics } = await this.get('apollo').watchQuery({ query: campaignMetrics, variables }, 'campaignHash');
         this.set('metrics', metrics);
       } catch (e) {
         this.get('graphErrors').show(e);

--- a/app/controllers/portal/campaigns/manage/report/summary.js
+++ b/app/controllers/portal/campaigns/manage/report/summary.js
@@ -14,7 +14,7 @@ export default Controller.extend({
     async runByDayReport({ startDate, endDate }) {
       this.set('isReportRunning', true);
       const variables = {
-        input: { hash: this.get('model.campaign.hash'), advertiserId: this.get('model.advertiser.id') },
+        input: { hash: this.get('model.hash'), advertiserId: this.get('model.advertiser.id') },
         startDate: startDate.startOf('day').valueOf(),
         endDate: endDate.startOf('day').valueOf(),
       };
@@ -31,7 +31,7 @@ export default Controller.extend({
     async retrieveCampaignMetrics() {
       this.set('areMetricsLoading', true);
       const variables = {
-        input: { hash: this.get('model.campaign.hash'), advertiserId: this.get('model.advertiser.id') },
+        input: { hash: this.get('model.hash'), advertiserId: this.get('model.advertiser.id') },
       };
       try {
         const { metrics } = await this.get('apollo').watchQuery({ query: campaignMetrics, variables }, 'campaignHash');

--- a/app/gql/fragments/account.graphql
+++ b/app/gql/fragments/account.graphql
@@ -6,5 +6,6 @@ fragment AccountFragment on Account {
     id
     reservePct
     cname
+    requiredCreatives
   }
 }

--- a/app/gql/fragments/campaign/portal/manage/materials.graphql
+++ b/app/gql/fragments/campaign/portal/manage/materials.graphql
@@ -27,6 +27,7 @@ fragment CampaignPortalManageMaterialsFragment on Campaign {
       ...ImageViewFragment
     }
   }
+  requiredCreatives
   creatives {
     ...CampaignCreativeFragment
   }

--- a/app/gql/fragments/campaign/portal/manage/materials.graphql
+++ b/app/gql/fragments/campaign/portal/manage/materials.graphql
@@ -1,0 +1,42 @@
+#import 'fortnight/gql/fragments/campaign-creative'
+#import 'fortnight/gql/fragments/image/src'
+
+fragment CampaignPortalManageMaterialsFragment on Campaign {
+  id
+  name
+  description
+  status
+  hash
+  url
+  criteria {
+    start
+    end
+  }
+  primaryImage {
+    ...ImageSrcFragment
+  }
+  story {
+    id
+    title
+    teaser
+    body
+    placeholder
+    publishedAt
+    previewUrl
+    primaryImage {
+      ...ImageViewFragment
+    }
+  }
+  creatives {
+    ...CampaignCreativeFragment
+  }
+  notify {
+    external {
+      id
+      name
+      givenName
+      familyName
+      email
+    }
+  }
+}

--- a/app/gql/queries/dashboard/publisher-breakouts.graphql
+++ b/app/gql/queries/dashboard/publisher-breakouts.graphql
@@ -1,20 +1,6 @@
-query DashboardPublisherBreakouts($input: PublisherMetricsInput!) {
-  publisherMetricBreakouts(input: $input) {
-    publisher {
-      id
-      name
-    }
-    placement {
-      id
-      template {
-        id
-        name
-      }
-    }
-    topic {
-      id
-      name
-    }
+query DashboardPublisherBreakouts($input: BreakoutMetricsInput!, $sort: PublisherMetricsSortInput!) {
+  publisherMetricBreakouts(input: $input, sort: $sort) {
+    publisherName
     views
     clicks
     ctr

--- a/app/gql/queries/dashboard/publisher-breakouts.graphql
+++ b/app/gql/queries/dashboard/publisher-breakouts.graphql
@@ -6,15 +6,7 @@ query DashboardPublisherBreakouts($input: PublisherMetricsInput!) {
     }
     placement {
       id
-      publisher {
-        id
-        name
-      }
       template {
-        id
-        name
-      }
-      topic {
         id
         name
       }
@@ -22,10 +14,6 @@ query DashboardPublisherBreakouts($input: PublisherMetricsInput!) {
     topic {
       id
       name
-      publisher {
-        id
-        name
-      }
     }
     views
     clicks

--- a/app/gql/queries/dashboard/topic-breakouts.graphql
+++ b/app/gql/queries/dashboard/topic-breakouts.graphql
@@ -1,0 +1,9 @@
+query DashboardTopicBreakouts($input: BreakoutMetricsInput!, $sort: TopicMetricsSortInput!) {
+  topicMetricBreakouts(input: $input, sort: $sort) {
+    publisherName
+    topicName
+    views
+    clicks
+    ctr
+  }
+}

--- a/app/gql/queries/portal/campaigns/manage.graphql
+++ b/app/gql/queries/portal/campaigns/manage.graphql
@@ -1,0 +1,6 @@
+query PortalCampaignsManage($input: CampaignHashInput!) {
+  campaignHash(input: $input) {
+    id
+    hash
+  }
+}

--- a/app/gql/queries/portal/campaigns/manage/materials.graphql
+++ b/app/gql/queries/portal/campaigns/manage/materials.graphql
@@ -1,0 +1,7 @@
+#import 'fortnight/gql/fragments/campaign/portal/manage/materials'
+
+query PortalCampaignsManageMaterials($input: CampaignHashInput!) {
+  campaignHash(input: $input) {
+    ...CampaignPortalManageMaterialsFragment
+  }
+}

--- a/app/gql/queries/portal/campaigns/manage/report/creative-breakdown.graphql
+++ b/app/gql/queries/portal/campaigns/manage/report/creative-breakdown.graphql
@@ -1,0 +1,11 @@
+#import 'fortnight/gql/fragments/campaign-creative'
+
+query PortalCampaignsManageReportCreativeBreakdown($input: CampaignHashInput!) {
+  campaignHash(input: $input) {
+    id
+    hash
+    creatives {
+      ...CampaignCreativeFragment
+    }
+  }
+}

--- a/app/gql/queries/portal/campaigns/manage/report/summary.graphql
+++ b/app/gql/queries/portal/campaigns/manage/report/summary.graphql
@@ -1,0 +1,24 @@
+#import 'fortnight/gql/fragments/image/src'
+
+query PortalCampaignsManageReportSummary($input: CampaignHashInput!) {
+  campaignHash(input: $input) {
+    id
+    hash
+    name
+    description
+    criteria {
+      start
+      end
+    }
+    advertiser {
+      id
+    }
+    story {
+      id
+      title
+    }
+    primaryImage {
+      ...ImageSrcFragment
+    }
+  }
+}

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -6,7 +6,6 @@ export default Route.extend(UnauthenticatedRouteMixin, {
   session: inject(),
 
   beforeModel() {
-    // this.showLoading();
-    this.get('session').invalidate().finally(() => this.hideLoading());
+    return this.get('session').invalidate();
   }
 });

--- a/app/routes/portal/campaigns/manage.js
+++ b/app/routes/portal/campaigns/manage.js
@@ -1,17 +1,13 @@
 import Route from '@ember/routing/route';
 import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
-import { hash, resolve } from 'rsvp';
 
-import query from 'fortnight/gql/queries/campaign/hash';
+import query from 'fortnight/gql/queries/portal/campaigns/manage';
 
 export default Route.extend(RouteQueryManager, {
   model({ campaign_hash }) {
     const advertiser = this.modelFor('portal');
     const variables = { input: { hash: campaign_hash, advertiserId: advertiser.id } };
-    return hash({
-      advertiser: resolve(advertiser),
-      campaign: this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'campaignHash'),
-    });
+    return this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'campaignHash');
   },
 });
 

--- a/app/routes/portal/campaigns/manage/materials.js
+++ b/app/routes/portal/campaigns/manage/materials.js
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
 
-export default Route.extend({});
+import query from 'fortnight/gql/queries/portal/campaigns/manage/materials';
+
+export default Route.extend(RouteQueryManager, {
+  model() {
+    const { hash } = this.modelFor('portal.campaigns.manage');
+    const advertiserId = this.modelFor('portal').id;
+    const variables = { input: { hash, advertiserId } };
+    return this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'campaignHash');
+  },
+});

--- a/app/routes/portal/campaigns/manage/materials/creatives/create.js
+++ b/app/routes/portal/campaigns/manage/materials/creatives/create.js
@@ -2,11 +2,11 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model() {
-    const { advertiser, campaign } = this.modelFor('portal.campaigns.manage');
-    return {
-      advertiser,
-      campaign,
-      creative: {},
-    };
+    return {};
+  },
+
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.set('campaign', this.modelFor('portal.campaigns.manage'))
   },
 });

--- a/app/routes/portal/campaigns/manage/materials/creatives/edit.js
+++ b/app/routes/portal/campaigns/manage/materials/creatives/edit.js
@@ -1,19 +1,18 @@
 import Route from '@ember/routing/route';
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
-import { hash, resolve } from 'rsvp';
 
 import query from 'fortnight/gql/queries/campaign/creative';
 
 export default Route.extend(RouteQueryManager, {
-
   model({ creative_id }) {
-    const { advertiser, campaign } = this.modelFor('portal.campaigns.manage');
-    const input = { campaignId: campaign.id, creativeId: creative_id };
+    const campaignId = this.modelFor('portal.campaigns.manage').id
+    const input = { campaignId, creativeId: creative_id };
     const variables = { input };
-    return hash({
-      advertiser: resolve(advertiser),
-      campaign: resolve(campaign),
-      creative: this.get('apollo').watchQuery({ query, variables, refetchPolicy: 'network-only' }, 'campaignCreative'),
-    });
+    return this.get('apollo').watchQuery({ query, variables, refetchPolicy: 'network-only' }, 'campaignCreative');
+  },
+
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.set('campaign', this.modelFor('portal.campaigns.manage.materials'));
   },
 });

--- a/app/routes/portal/campaigns/manage/report/creative-breakdown.js
+++ b/app/routes/portal/campaigns/manage/report/creative-breakdown.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+
+import query from 'fortnight/gql/queries/portal/campaigns/manage/report/creative-breakdown';
+
+export default Route.extend(RouteQueryManager, {
+  model() {
+    const { hash } = this.modelFor('portal.campaigns.manage');
+    const advertiserId = this.modelFor('portal').id;
+    const variables = { input: { hash, advertiserId } };
+    return this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'campaignHash');
+  },
+});

--- a/app/routes/portal/campaigns/manage/report/summary.js
+++ b/app/routes/portal/campaigns/manage/report/summary.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+
+import query from 'fortnight/gql/queries/portal/campaigns/manage/report/summary';
+
+export default Route.extend(RouteQueryManager, {
+  model() {
+    const { hash } = this.modelFor('portal.campaigns.manage');
+    const advertiserId = this.modelFor('portal').id;
+    const variables = { input: { hash, advertiserId } };
+    return this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'campaignHash');
+  },
+});

--- a/app/services/autocomplete.js
+++ b/app/services/autocomplete.js
@@ -55,7 +55,7 @@ export default Service.extend({
     };
     const { query, resultKey } = this.getQueryFor(type);
     try {
-      const results = await this.get('apollo').query({ query, variables, fetchPolicy: 'network-only' }, resultKey);
+      const results = await this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, resultKey);
       return results.edges.map(edge => edge.node);
     } catch (e) {
       this.get('graphErrors').show(e);

--- a/app/services/user.js
+++ b/app/services/user.js
@@ -4,6 +4,7 @@ import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager'
 
 export default Service.extend(ObjectQueryManager, {
   loadingDisplay: inject(),
+  graphErrors: inject(),
   session: inject(),
   auth: inject(),
 
@@ -22,11 +23,15 @@ export default Service.extend(ObjectQueryManager, {
     return roles.includes(role);
   },
 
-  logout() {
+  async logout() {
     const loader = this.get('loadingDisplay');
     loader.show();
-    return this.get('session').invalidate()
-      .finally(loader.hide())
-    ;
+    try {
+      await this.get('session').invalidate();
+    } catch (e) {
+      this.get('graphErrors').show(e);
+    } finally {
+      loader.hide();
+    }
   }
 });

--- a/app/templates/components/-report/sort-field.hbs
+++ b/app/templates/components/-report/sort-field.hbs
@@ -1,0 +1,9 @@
+{{#if isActive}}
+  {{#if ascending}}
+    {{entypo-icon "triangle-up" class="text-info"}}
+  {{else}}
+    {{entypo-icon "triangle-down" class="text-info"}}
+  {{/if}}
+{{else}}
+  {{entypo-icon "select-arrows" class="text-muted"}}
+{{/if}}

--- a/app/templates/components/dashboard/publisher-breakouts.hbs
+++ b/app/templates/components/dashboard/publisher-breakouts.hbs
@@ -56,12 +56,12 @@
               <td>{{row.publisher.name}}</td>
             {{/if}}
             {{#if (eq breakout "placement")}}
-              <td>{{row.placement.publisher.name}}</td>
-              <td>{{row.placement.topic.name}}</td>
+              <td>{{row.publisher.name}}</td>
+              <td>{{row.topic.name}}</td>
               <td>{{row.placement.template.name}}</td>
             {{/if}}
             {{#if (eq breakout "topic")}}
-              <td>{{row.topic.publisher.name}}</td>
+              <td>{{row.publisher.name}}</td>
               <td>{{row.topic.name}}</td>
             {{/if}}
             <td>{{number-format row.views "0,0"}}</td>

--- a/app/templates/components/dashboard/publisher-breakouts.hbs
+++ b/app/templates/components/dashboard/publisher-breakouts.hbs
@@ -17,10 +17,6 @@
           {{radio-button radioId="breakout-topic" radioClass="custom-control-input" value="topic" groupValue=breakout changed=(action "setBreakout")}}
           <label class="custom-control-label mr-3" for="breakout-topic">Topic</label>
         </div>
-        <div class="custom-control custom-radio">
-          {{radio-button radioId="breakout-placement" radioClass="custom-control-input" value="placement" groupValue=breakout changed=(action "setBreakout")}}
-          <label class="custom-control-label" for="breakout-placement">Placement</label>
-        </div>
       </div>
 
     </div>
@@ -32,37 +28,41 @@
     <table class="table table-sm table-hover mb-0">
       <thead>
         <tr>
-          {{#if (eq breakout "publisher")}}
-            <th>Publisher</th>
-          {{/if}}
+          <th>
+            Publisher
+            {{-report/sort-field key="publisherName" sortBy=sortBy ascending=ascending reset=false}}
+          </th>
           {{#if (eq breakout "topic")}}
-            <th>Publisher</th>
-            <th>Topic</th>
+            <th>
+              Topic
+              {{-report/sort-field key="topicName" sortBy=sortBy ascending=ascending reset=false}}
+            </th>
           {{/if}}
-          {{#if (eq breakout "placement")}}
-            <th>Publisher</th>
-            <th>Topic</th>
-            <th>Placement</th>
-          {{/if}}
-          <th>Views</th>
-          <th>Clicks</th>
-          <th>CTR</th>
+          <th>
+            Views
+            {{-report/sort-field key="views" sortBy=sortBy ascending=ascending reset=false}}
+          </th>
+          <th>
+            Clicks
+            {{-report/sort-field key="clicks" sortBy=sortBy ascending=ascending reset=false}}
+          </th>
+          <th>
+            CTR
+            {{-report/sort-field key="ctr" sortBy=sortBy ascending=ascending reset=false}}
+          </th>
         </tr>
       </thead>
       <tbody>
         {{#each rows as |row|}}
           <tr>
             {{#if (eq breakout "publisher")}}
-              <td>{{row.publisher.name}}</td>
-            {{/if}}
-            {{#if (eq breakout "placement")}}
-              <td>{{row.publisher.name}}</td>
-              <td>{{row.topic.name}}</td>
-              <td>{{row.placement.template.name}}</td>
+              <td>
+                {{row.publisherName}}
+              </td>
             {{/if}}
             {{#if (eq breakout "topic")}}
-              <td>{{row.publisher.name}}</td>
-              <td>{{row.topic.name}}</td>
+              <td>{{row.publisherName}}</td>
+              <td>{{row.topicName}}</td>
             {{/if}}
             <td>{{number-format row.views "0,0"}}</td>
             <td>{{number-format row.clicks "0,0"}}</td>
@@ -73,62 +73,3 @@
     </table>
   {{/if}}
 </div>
-
-
-{{!-- <div class="card-body">
-  {{#if isLoading}}
-    <small class="text-muted">Loading data...</small>
-    {{progress-bar show=true}}
-  {{else}}
-    <h5 class="text-muted card-title">Total Results: {{data.totalCount}}</h5>
-    {{#fetch-more
-      class="table-responsive"
-      query=observable
-      edges=data.edges
-      hasNextPage=data.pageInfo.hasNextPage
-      endCursor=data.pageInfo.endCursor
-      on-fetch-start=(route-action "showLoading")
-      on-fetch-end=(route-action "hideLoading")
-      resultKey="allPublishers" as |fetch|
-    }}
-      <table class="table table-sm table-hover mb-0">
-        <thead>
-          <tr>
-            <th>Publisher</th>
-            <th>Views</th>
-            <th>Clicks</th>
-            <th>CTR</th>
-          </tr>
-        </thead>
-        <tbody>
-
-          {{#each fetch.nodes as |item|}}
-            <tr>
-              <td>{{#link-to "manage.publisher.edit" item.id}}{{item.name}}{{/link-to}}</td>
-              {{#with item.metrics as |metrics|}}
-                <td>{{number-format metrics.views "0,0"}}</td>
-                <td>{{number-format metrics.clicks "0,0"}}</td>
-                <td>{{number-format metrics.ctr "0.[000]%"}}</td>
-              {{/with}}
-            </tr>
-          {{else}}
-            <tr>
-              <td colspan="4" class="text-center text-muted">No publishers found.</td>
-            </tr>
-          {{/each}}
-
-        </tbody>
-
-        {{#if fetch.hasNextPage}}
-          <tfoot>
-            <tr colspan="4">
-              <button class="btn btn-primary btn-sm mt-2" disabled={{fetch.isFetching}} {{action fetch.actions.loadMore}}>
-                {{entypo-icon "download"}} {{#if fetch.isFetching}}Loading...{{else}}Load More{{/if}}
-              </button>
-            </tr>
-          </tfoot>
-        {{/if}}
-      </table>
-    {{/fetch-more}}
-  {{/if}}
-</div> --}}

--- a/app/templates/components/materials/story-builder.hbs
+++ b/app/templates/components/materials/story-builder.hbs
@@ -70,7 +70,7 @@
 
   <hr>
 
-  <p class="form-text">Once your story is complete, click the toggle below to publish it. You <em>must</em> publish your story or it will not display when visited.</p>
+  <p class="form-text"><strong>Note:</strong> Once your story is complete, you <em>must</em> click the toggle below to publish it. If it remains unpublished, it will not display when visited.</p>
   {{#x-toggle
     class="justify-content-start"
     size="medium"
@@ -82,7 +82,15 @@
     onToggle=(action "togglePublished") as |toggle|
   }}
     {{toggle.switch class="w-auto px-0"}}
-    {{toggle.onLabel class="font-weight-bold text-muted"}}
+    {{#toggle.label value=isPublished}}
+      <span class="font-weight-bold text-muted">
+        {{#if isPublished}}
+          {{entypo-icon "check" class="text-success"}} Published
+        {{else}}
+          {{entypo-icon "warning" class="text-warning"}} Unpublished
+        {{/if}}
+      </span>
+    {{/toggle.label}}
   {{/x-toggle}}
 
 </div>

--- a/app/templates/components/story-editor.hbs
+++ b/app/templates/components/story-editor.hbs
@@ -15,6 +15,7 @@
       H4="Heading 4"
     )
     paragraphFormatSelection=true
+    videoUpload=false
     imageUploadURL="/upload/story-image"
     imageUploadParams=(hash
       storyId=storyId

--- a/app/templates/manage/account.hbs
+++ b/app/templates/manage/account.hbs
@@ -93,7 +93,7 @@
               focusOut=(action form.actions.autosave)
               keyUp=(action form.actions.autosave 750)
             }}
-            <small class="form-text text-muted">The number of creatives required on a campaign.</small>
+            <small class="form-text text-muted">The number of creatives required on a campaign. Changing this only affects go-foward campaigns.</small>
           </div>
 
         </div>

--- a/app/templates/manage/account.hbs
+++ b/app/templates/manage/account.hbs
@@ -37,7 +37,7 @@
       </div>
 
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-4">
 
           <div class="form-group mb-0">
             <label for="account-cname">Custom CNAME</label>
@@ -54,7 +54,7 @@
           <small class="form-text text-muted">A custom CNAME for your account, configured by NativeX support.</small>
 
         </div>
-        <div class="col-md-6">
+        <div class="col-md-4">
 
           <div class="form-group mb-0">
             <label for="account-reserve-pct">Impression Reserve</label>
@@ -75,6 +75,25 @@
               </div>
             </div>
             <small class="form-text text-muted">The share of impressions dedicated to serving content, rather than a campaign.</small>
+          </div>
+
+        </div>
+
+        <div class="col-md-4">
+
+          <div class="form-group mb-0">
+            <label for="account-required-creatives">Required Creatives</label>
+            {{input
+              type="number"
+              min=0
+              max=10
+              value=form.model.settings.requiredCreatives
+              class="form-control"
+              id="account-required-creatives"
+              focusOut=(action form.actions.autosave)
+              keyUp=(action form.actions.autosave 750)
+            }}
+            <small class="form-text text-muted">The number of creatives required on a campaign.</small>
           </div>
 
         </div>

--- a/app/templates/manage/story/forms/edit.hbs
+++ b/app/templates/manage/story/forms/edit.hbs
@@ -62,7 +62,7 @@
         {{story-published-at
           publishedAt=form.model.publishedAt
           status=form.model.status
-          onSelect=(action form.actions.setAndAutosave "publishedAt")
+          onSelect=(action "setPublishedAt" form.model.id)
         }}
       </div>
     </div>

--- a/app/templates/portal/campaigns/manage/materials.hbs
+++ b/app/templates/portal/campaigns/manage/materials.hbs
@@ -18,10 +18,10 @@
       <div class="card mb-4 border-0 z-depth-half">
         <div class="card-body pb-1">
           <h5 class="card-title font-weight-bold text-uppercase text-info mb-0">
-            Creatives
+            Ad Campaign Creatives
           </h5>
           <div class="text-muted mb-3">
-            Build your native ad unit.
+            Build your native ad unit. These creatives will link to the {{#if model.story.id}}story{{else}}URL{{/if}} above.
           </div>
 
           <div class="row">
@@ -49,11 +49,26 @@
                 <div class="card-body text-center d-flex flex-column justify-content-center">
                   {{entypo-icon "circle-with-plus" class="h1"}}
                   <span class="h4">Add Creative</span>
+                  <span class="h6">{{#if remainingCreatives}}({{remainingCreatives}} more required){{/if}}</span>
                 </div>
               {{/link-to}}
 
             </div>
           </div>
+
+          {{#if remainingCreatives}}
+            <p class="card-text mb-3">
+              <span class="font-weight-bold">Note:</span>
+              You must provide <span class="font-italic">at least</span> <span class="font-weight-bold text-info">{{remainingCreatives}}</span> more active {{remainingCreativesLabel}} in order for your campaign to start. Additional creatives beyond this requirement are encouraged.
+            </p>
+          {{/if}}
+
+          {{#if model.creatives.length}}
+            <p class="card-text mb-3">
+              If you no longer wish to display a creative, change it from
+              <span class="text-success">{{entypo-icon "flag"}} Active</span> to <span class="text-warning">{{entypo-icon "flag"}} Draft</span>.
+            </p>
+          {{/if}}
 
         </div>
       </div>

--- a/app/templates/portal/campaigns/manage/materials.hbs
+++ b/app/templates/portal/campaigns/manage/materials.hbs
@@ -7,8 +7,8 @@
         <span class="text-uppercase">Materials Builder</span>
       </h3>
 
-      {{#if model.campaign.story.id}}
-        {{materials/story-builder class="mb-4" story=model.campaign.story}}
+      {{#if model.story.id}}
+        {{materials/story-builder class="mb-4" story=model.story}}
       {{else}}
         <div class="card mb-4 border-0 z-depth-half">
           {{partial "portal/campaigns/manage/materials/campaign"}}
@@ -25,7 +25,7 @@
           </div>
 
           <div class="row">
-            {{#each model.campaign.creatives as |creative|}}
+            {{#each model.creatives as |creative|}}
               <div class="mb-3 col-12 col-lg-6">
                 {{campaign-creative
                   canRemove=canRemoveCreatives
@@ -34,7 +34,7 @@
                   displayPreviewButton=true
                   previewRouteName="portal.campaigns.manage.materials.creatives.edit.preview"
                   creativeId=creative.id
-                  campaignId=model.campaign.id
+                  campaignId=model.id
                   title=creative.title
                   teaser=creative.teaser
                   active=creative.active
@@ -57,7 +57,7 @@
         </div>
       </div>
 
-      {{materials/contacts-builder campaign=model.campaign}}
+      {{materials/contacts-builder campaign=model}}
 
     </div>
   </div>

--- a/app/templates/portal/campaigns/manage/materials.hbs
+++ b/app/templates/portal/campaigns/manage/materials.hbs
@@ -28,7 +28,8 @@
             {{#each model.creatives as |creative|}}
               <div class="mb-3 col-12 col-lg-6">
                 {{campaign-creative
-                  canRemove=canRemoveCreatives
+                  canRemove=false
+                  canModifyStatus=true
                   editRouteName="portal.campaigns.manage.materials.creatives.edit"
                   displayEditButton=true
                   displayPreviewButton=true

--- a/app/templates/portal/campaigns/manage/materials/campaign.hbs
+++ b/app/templates/portal/campaigns/manage/materials/campaign.hbs
@@ -1,5 +1,5 @@
 <div class="card-body">
-  {{-report/campaign-title campaign=model.campaign}}
+  {{-report/campaign-title campaign=model}}
 
   {{#auto-save/form as |form|}}
     <div class="form-group mb-0">
@@ -9,7 +9,7 @@
         id="campaign-url"
         class="form-control"
         type="url"
-        value=model.campaign.url
+        value=model.url
         placeholder="https://www.yourlink.com"
         required=true
         on-change=(action "saveField" "url" "Click URL")

--- a/app/templates/portal/campaigns/manage/materials/creatives/create/image.hbs
+++ b/app/templates/portal/campaigns/manage/materials/creatives/create/image.hbs
@@ -1,5 +1,5 @@
 {{#model-form
-  model=model.creative
+  model=model
   shouldAutosave=false
   onSubmit=(action "create") as |form|
 }}

--- a/app/templates/portal/campaigns/manage/materials/creatives/create/index.hbs
+++ b/app/templates/portal/campaigns/manage/materials/creatives/create/index.hbs
@@ -1,5 +1,5 @@
 {{#model-form
-  model=model.creative
+  model=model
   shouldAutosave=false
   onInit=(route-action "setDetailsForm")
   onSubmit=(route-action "transitionTo" "portal.campaigns.manage.materials.creatives.create.image")  as |form|

--- a/app/templates/portal/campaigns/manage/materials/creatives/edit/image.hbs
+++ b/app/templates/portal/campaigns/manage/materials/creatives/edit/image.hbs
@@ -1,5 +1,5 @@
 {{#model-form
-  model=model.creative
+  model=model
   shouldAutosave=false as |form|
 }}
   {{progress-bar show=isActionRunning}}

--- a/app/templates/portal/campaigns/manage/materials/creatives/edit/index.hbs
+++ b/app/templates/portal/campaigns/manage/materials/creatives/edit/index.hbs
@@ -1,5 +1,5 @@
 {{#model-form
-  model=model.creative
+  model=model
   shouldAutosave=true
   onInit=(route-action "setDetailsForm")
   onSubmit=(action "updateDetails") as |form|

--- a/app/templates/portal/campaigns/manage/materials/creatives/edit/index.hbs
+++ b/app/templates/portal/campaigns/manage/materials/creatives/edit/index.hbs
@@ -9,6 +9,6 @@
   {{/bs-modal/body}}
 
   {{#bs-modal/footer class="d-flex justify-content-between"}}
-    <button class="btn btn-success" disabled={{isActionRunning}} {{action (route-action "hideModal")}}>{{entypo-icon "check"}} OK</button>
+    <button class="btn btn-success" {{action (route-action "hideModal")}}>{{entypo-icon "check"}} OK</button>
   {{/bs-modal/footer}}
 {{/model-form}}

--- a/app/templates/portal/campaigns/manage/materials/creatives/edit/preview.hbs
+++ b/app/templates/portal/campaigns/manage/materials/creatives/edit/preview.hbs
@@ -6,8 +6,8 @@
     How your ad units will display.
   </div>
   <div class="row">
-    {{campaign-creative/preview-grid class="col-lg-6 mb-2" creative=model.creative campaign=model.campaign}}
-    {{campaign-creative/preview-list class="col-lg-6 mb-2" creative=model.creative campaign=model.campaign}}
+    {{campaign-creative/preview-grid class="col-lg-6 mb-2" creative=model campaign=campaign}}
+    {{campaign-creative/preview-list class="col-lg-6 mb-2" creative=model campaign=campaign}}
   </div>
 {{/bs-modal/body}}
 

--- a/app/templates/portal/campaigns/manage/report/creative-breakdown.hbs
+++ b/app/templates/portal/campaigns/manage/report/creative-breakdown.hbs
@@ -8,21 +8,21 @@
         </div>
       </div>
 
-      {{#each model.campaign.creatives as |creative|}}
+      {{#each model.creatives as |creative|}}
         <hr>
         <div class="row">
 
           <div class="col-lg-4">
             <div class="card z-depth-half bg-white mb-4">
               <div class="card-body">
-                {{campaign-creative/preview-grid creative=creative campaign=model.campaign}}
+                {{campaign-creative/preview-grid creative=creative campaign=model}}
               </div>
             </div>
           </div>
 
           <div class="col-lg-8">
             {{-report/campaign/creative
-              campaignId=model.campaign.id
+              campaignId=model.id
               creativeId=creative.id
             }}
           </div>
@@ -30,86 +30,8 @@
         </div>
         <hr>
 
-
-
-        {{!-- <div class="row">
-          <div class="col">
-            {{-report/creative-card
-              creative=creativeSummary.creative
-              campaign=model.campaignHash
-              clicks=creativeSummary.clicks
-              views=creativeSummary.views
-              ctr=creativeSummary.ctr
-              totalClicks=clicks
-              totalViews=impressions
-              totalCtr=ctr
-            }}
-          </div>
-        </div> --}}
       {{/each}}
 
     </div>
   </div>
 </div>
-
-
-{{!-- <div class="container my-3">
-
-  <div class="row mb-3">
-    <div class="col">
-      <h3 class="mb-0 font-weight-bold text-muted">
-        <span class="text-uppercase">Creative Report</span>
-        <span class="h6 text-muted">a breakdown of how your individual creatives are performing</span>
-      </h3>
-    </div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col">
-      <div class="card">
-        <div class="card-body">
-          {{-report/campaign-title campaign=campaign}}
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {{#each model.creatives as |creativeSummary|}}
-  <div class="row">
-    <div class="col">
-      {{-report/creative-card
-        creative=creativeSummary.creative
-        campaign=model.campaignHash
-        clicks=creativeSummary.clicks
-        views=creativeSummary.views
-        ctr=creativeSummary.ctr
-        totalClicks=clicks
-        totalViews=impressions
-        totalCtr=ctr
-      }}
-    </div>
-  </div>
-  {{/each}}
-
-
-  <div class="row mb-3">
-    <div class="col">
-      {{-report/data-chart
-        title="Daily impressions by creative"
-        series=impressionSummary.data
-        options=impressionSummary.options
-      }}
-    </div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col">
-      {{-report/data-chart
-        title="Daily click-through rate by creative"
-        series=ctrSummary.data
-        options=ctrSummary.options
-      }}
-    </div>
-  </div>
-
-</div> --}}

--- a/app/templates/portal/campaigns/manage/report/summary.hbs
+++ b/app/templates/portal/campaigns/manage/report/summary.hbs
@@ -14,32 +14,32 @@
 
             <div class="d-flex flex-column">
               <div class="d-flex flex-row">
-                {{#if model.campaign.primaryImage.src}}
+                {{#if model.primaryImage.src}}
                   <div class="d-flex flex-column my-auto mr-3">
                     {{imgix-img
-                      originalSrc=model.campaign.primaryImage.src
+                      originalSrc=model.primaryImage.src
                       width=192
                       height=108
                       w="192"
                       h="108"
                       fit="crop"
                       crop="focalpoint"
-                      fp-x=model.campaign.primaryImage.focalPoint.x
-                      fp-y=model.campaign.primaryImage.focalPoint.y
+                      fp-x=model.primaryImage.focalPoint.x
+                      fp-y=model.primaryImage.focalPoint.y
                     }}
                   </div>
                 {{/if}}
                 <div class="d-flex flex-column">
-                  <h4 class="mb-1">{{model.campaign.name}}</h4>
-                  {{#if model.campaign.description}}
-                    <h5 class="mb-1">{{model.campaign.description}}</h5>
+                  <h4 class="mb-1">{{model.name}}</h4>
+                  {{#if model.description}}
+                    <h5 class="mb-1">{{model.description}}</h5>
                   {{/if}}
-                  {{#if model.campaign.story.id}}
-                    <p class="mb-1">Story: {{model.campaign.story.title}}</p>
+                  {{#if model.story.id}}
+                    <p class="mb-1">Story: {{model.story.title}}</p>
                   {{/if}}
                   <div class="mt-auto">
-                    {{campaign-date futureLabel="Starts" pastLabel="Started" date=model.campaign.criteria.start}}
-                    {{campaign-date futureLabel="Ends" pastLabel="Ended" date=model.campaign.criteria.end}}
+                    {{campaign-date futureLabel="Starts" pastLabel="Started" date=model.criteria.start}}
+                    {{campaign-date futureLabel="Ends" pastLabel="Ended" date=model.criteria.end}}
                   </div>
                 </div>
               </div>

--- a/tests/unit/services/user-test.js
+++ b/tests/unit/services/user-test.js
@@ -3,7 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('service:user', 'Unit | Service | user', {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
-  needs: [ 'service:session', 'service:apollo', 'service:loadingDisplay', 'service:auth' ]
+  needs: [ 'service:graphErrors', 'service:session', 'service:apollo', 'service:loadingDisplay', 'service:auth' ]
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
- Remove references to `.finally()` in promises (prevents errors in mobile Safari)
- Remove excessive loading bar from MCF
- Ensure creatives and contacts display/refresh on create
- Update publisher/topic breakouts on dashboard to use new graph queries and support sorting
- Fix issue with the published date being reset on delete error
- Prevent MCF from deleting creatives; instead, allow them to activate/deactivate them
- Add required creatives messaging and better story publishing on MCF
- Add 1.19:1 crop preview to image component
