### PR TITLE
Ensure remaining creatives stays at 0 when less than 0

### DIFF
--- a/app/controllers/portal/campaigns/manage/materials.js
+++ b/app/controllers/portal/campaigns/manage/materials.js
@@ -13,7 +13,8 @@ export default Controller.extend(ActionMixin, {
   activeCreatives: computed.filterBy('model.creatives', 'active', true),
 
   remainingCreatives: computed('model.requiredCreatives', 'activeCreatives.length', function() {
-    return this.get('model.requiredCreatives') - this.get('activeCreatives.length');
+    const value = this.get('model.requiredCreatives') - this.get('activeCreatives.length');
+    return value < 0 ? 0 : value;
   }),
 
   remainingCreativesLabel: computed('remainingCreatives', function() {


### PR DESCRIPTION
Prevents this:
![image](https://user-images.githubusercontent.com/3289485/44794819-eade7580-ab6e-11e8-9392-8f5a6ebcbdcb.png)
