### PR TITLE
Change default report dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ package.json.ember-try
 .DS_Store
 coverage
 .nyc_output
+.env

--- a/app/controllers/portal/campaigns/manage/report/creative-breakdown.js
+++ b/app/controllers/portal/campaigns/manage/report/creative-breakdown.js
@@ -1,8 +1,21 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import ImpressionDataMixin from 'fortnight/mixins/impression-data-mixin';
+import moment from 'moment'
 
 export default Controller.extend(ImpressionDataMixin, {
+
+  startDate: computed('model.criteria.start', function() {
+    const start = this.get('model.criteria.start');
+    if (start) return moment(start);
+    return moment().subtract(14, 'days');
+  }),
+
+  endDate: computed('model.criteria.end', function() {
+    const end = this.get('model.criteria.end');
+    const now = moment();
+    return end > now ? now : moment(end);
+  }),
 
   impressionSummaryTimeSeries: computed('model.creatives.@each', function() {
     return this.get('model.creatives').map(item => {

--- a/app/controllers/portal/campaigns/manage/report/creative-breakdown.js
+++ b/app/controllers/portal/campaigns/manage/report/creative-breakdown.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import ImpressionDataMixin from 'fortnight/mixins/impression-data-mixin';
-import moment from 'moment'
+import moment from 'moment';
 
 export default Controller.extend(ImpressionDataMixin, {
 

--- a/app/controllers/portal/campaigns/manage/report/creative-breakdown.js
+++ b/app/controllers/portal/campaigns/manage/report/creative-breakdown.js
@@ -14,6 +14,7 @@ export default Controller.extend(ImpressionDataMixin, {
   endDate: computed('model.criteria.end', function() {
     const end = this.get('model.criteria.end');
     const now = moment();
+    if (!end) return now;
     return end > now ? now : moment(end);
   }),
 

--- a/app/controllers/portal/campaigns/manage/report/summary.js
+++ b/app/controllers/portal/campaigns/manage/report/summary.js
@@ -18,6 +18,7 @@ export default Controller.extend({
   endDate: computed('model.criteria.end', function() {
     const end = this.get('model.criteria.end');
     const now = moment();
+    if (!end) return now;
     return end > now ? now : moment(end);
   }),
 

--- a/app/controllers/portal/campaigns/manage/report/summary.js
+++ b/app/controllers/portal/campaigns/manage/report/summary.js
@@ -1,11 +1,25 @@
 import Controller from '@ember/controller';
 import { inject } from '@ember/service';
+import { computed } from '@ember/object';
+import moment from 'moment';
 
 import reportByDay from 'fortnight/gql/queries/campaign/reports/by-day';
 import campaignMetrics from 'fortnight/gql/queries/campaign/metrics';
 
 export default Controller.extend({
   apollo: inject(),
+
+  startDate: computed('model.criteria.start', function() {
+    const start = this.get('model.criteria.start');
+    if (start) return moment(start);
+    return moment().subtract(14, 'days');
+  }),
+
+  endDate: computed('model.criteria.end', function() {
+    const end = this.get('model.criteria.end');
+    const now = moment();
+    return end > now ? now : moment(end);
+  }),
 
   isReportRunning: false,
   areMetricsLoading: false,

--- a/app/gql/queries/portal/campaigns/manage/report/creative-breakdown.graphql
+++ b/app/gql/queries/portal/campaigns/manage/report/creative-breakdown.graphql
@@ -4,6 +4,10 @@ query PortalCampaignsManageReportCreativeBreakdown($input: CampaignHashInput!) {
   campaignHash(input: $input) {
     id
     hash
+    criteria {
+      start
+      end
+    }
     creatives {
       ...CampaignCreativeFragment
     }

--- a/app/templates/components/-report/campaign/creative.hbs
+++ b/app/templates/components/-report/campaign/creative.hbs
@@ -8,6 +8,8 @@
   <div class="col">
     {{-report/campaign/chart
       isLoading=isReportRunning
+      startDate=startDate
+      endDate=endDate
       rows=rows
       oninsert=(action "runByDayReport")
       onchange=(action "runByDayReport")

--- a/app/templates/portal/campaigns/manage/report/creative-breakdown.hbs
+++ b/app/templates/portal/campaigns/manage/report/creative-breakdown.hbs
@@ -22,6 +22,8 @@
 
           <div class="col-lg-8">
             {{-report/campaign/creative
+              startDate=startDate
+              endDate=endDate
               campaignId=model.id
               creativeId=creative.id
             }}

--- a/app/templates/portal/campaigns/manage/report/summary.hbs
+++ b/app/templates/portal/campaigns/manage/report/summary.hbs
@@ -58,6 +58,8 @@
 
       <h4 class="text-muted px-3 mb-2">Metrics Over Time</h4>
       {{-report/campaign/chart
+        startDate=startDate
+        endDate=endDate
         isLoading=isReportRunning
         rows=rows
         oninsert=(action "runByDayReport")
@@ -66,4 +68,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This change ensures that the summary and campaign detail reports include the proper (default) date context.
This will now set the initial dates based on the start and end date of the campaign -- but will set the end date to now if the campaign ends in the future.

Summary, production
![Screen Shot 2019-09-18 at 1 17 47 PM](https://user-images.githubusercontent.com/1778222/65174656-f5d4a400-da16-11e9-8a1b-8a4a68146e80.png)
Summary, this code
![Screen Shot 2019-09-18 at 1 17 37 PM](https://user-images.githubusercontent.com/1778222/65174657-f5d4a400-da16-11e9-807e-d6f270df3210.png)
Summary, production
![Screen Shot 2019-09-18 at 1 17 31 PM](https://user-images.githubusercontent.com/1778222/65174658-f5d4a400-da16-11e9-8815-c7daaceed7e7.png)
Summary, this code
![Screen Shot 2019-09-18 at 1 17 13 PM](https://user-images.githubusercontent.com/1778222/65174659-f66d3a80-da16-11e9-85b8-fae5c3579ea6.png)

Creative, prod
![Screen Shot 2019-09-18 at 1 12 45 PM](https://user-images.githubusercontent.com/1778222/65174660-f66d3a80-da16-11e9-8a86-6da71d53862a.png)

Creative, this code
![Screen Shot 2019-09-18 at 1 12 34 PM](https://user-images.githubusercontent.com/1778222/65174661-f66d3a80-da16-11e9-95ab-72659b251a78.png)
Creative, prod
![Screen Shot 2019-09-18 at 1 12 26 PM](https://user-images.githubusercontent.com/1778222/65174662-f66d3a80-da16-11e9-96b3-d62d165add9d.png)
Creative, this code
![Screen Shot 2019-09-18 at 1 12 08 PM](https://user-images.githubusercontent.com/1778222/65174663-f66d3a80-da16-11e9-801c-a839afc4d173.png)
